### PR TITLE
Correction TP

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.9.9
 RUN pip install Flask
 ADD TPCloudAnimals /
+VOLUME /var/lib/TPCloudAnimals
 CMD python frontend/app.py

--- a/README.md
+++ b/README.md
@@ -6,23 +6,24 @@ Développé par Quentin Colras
 
 Les étapes : 
 - Télécharger le fichier ZIP, l'extraire.
-- Se placer dans le dossier où il y a les sources et le Dockerfile et build l'image docker : docker build -t tpcloud/python-favanimal:1.0 .
-- Créer un container à partir de l'image : docker run -ti -p 8080:80 tpcloud/python-favanimal:1.0
-- Se rendre sur l'addresse internet : localhost:8080
+- Se placer dans le dossier où il y a les sources et le Dockerfile et build l'image docker : `docker build -t tpcloud/python-favanimal:1.0-correction .`
+- Créer un [volume docker](https://docs.docker.com/storage/volumes/) pour la persistence des données
+- Créer un container à partir de l'image : `docker run -ti -v TPCloudAnimals:/var/lib/TPCloudAnimals -p 8080:80 tpcloud/python-favanimal:1.0-correction`
+- Se rendre sur l'addresse internet : `http://localhost:8080`
 
 
 ## Description
 
 Pour ce mini projet, j'ai utilisé flask en python pour pouvoir écrire dans un fichier json.
 
-Pour décrire basiquement le projet, on lis un fichier JSON qui contient 2 paramètres : 
+Pour décrire basiquement le projet, on lit un fichier JSON qui contient 2 paramètres :
 - possibleAnimals : tableau des animaux possibles en lien avec les images, l'ordre de ce tableau est 
 important et correspond au image du code HTML
 - favoriteAnimal : le nom de l'animal préféré de l'utilisateur
 
-Lorsque l'utilisateur va sur l'url : localhost:8080, il se trouve devant une page web
-lui demandant de choisir son animal préféré, il peux alors faire glisser les images pour choisir son
-animal préféré parmi la liste prédéfini suivante : lion, panda, aigle, chien, dauphin, chat et cheval.
+Lorsque l'utilisateur va sur l'url : http://localhost:8080, il se trouve devant une page web
+lui demandant de choisir son animal préféré, il peut alors faire glisser les images pour choisir son
+animal préféré parmi la liste prédéfinie suivante : lion, panda, aigle, chien, dauphin, chat et cheval.
 
 Une fois sur celui-ci on peut sauvegarder son choix en cliquant sur sauvegarder
 
@@ -33,7 +34,7 @@ peu importe qu'il recharge la page sur une autre image que celle de son choix pr
 
 Concernant la persistance des données, lorsque le container de l'image est supprimé, et que l'on
 créer un nouveau container à partir de celle-ci, le choix de l'utilisateur est bien sauvegardé et on le 
-remarque facilement par le fait qu'on sera redirigé vers le choix favoris lors du chargement de la page.
+controller avec la commande sur le container `docker exec -t {{le nom du container}} cat /var/lib/TPCloudAnimals/config.json` ou directement via le volume `docker volume inspect TPCloudAnimals | jq '.[].Mountpoint' | sudo xargs ls`.
 
 
 Par exemple dans le cas-ci dessous, lorsque l'on choisis de sauvegarder "cheval" en tant qu'animal favoris, lorsque l'on recharge la page, on tombera sur l'image du cheval en premier.

--- a/TPCloudAnimals/frontend/functions/json_tools.py
+++ b/TPCloudAnimals/frontend/functions/json_tools.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-path = "frontend/static/js/config.json"
+path = "/var/lib/TPCloudAnimals/config.json"
         
 def save_config(listeAnimals, favorite):
     try:


### PR DESCRIPTION
- Inutile de committer le cache python puisqu'il est builder dans
  l'image docker; de fait ajout du `.dockerignore`.
  Il faudrait faire de même avec `.gitignore`.
- La précédente version n'avait **pas** la persitence des données.
  Ce peut être vérifier en éxécutant différent container et en vérifiant
  le fichier json.
  De fait ajout d'un docker volume (un simple mount était correct
  également).